### PR TITLE
feat: Add new atoms, atoms file and better player movement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,6 +249,7 @@ dependencies = [
  "fastrand 2.0.1",
  "itertools",
  "rand",
+ "ron",
  "serde",
  "serde-big-array",
  "serde_derive",
@@ -468,6 +469,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "base64"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
+
+[[package]]
 name = "bevy"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,6 +606,7 @@ dependencies = [
  "futures-io",
  "futures-lite 1.13.0",
  "js-sys",
+ "notify-debouncer-full",
  "parking_lot",
  "ron",
  "serde",
@@ -808,7 +816,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85adc6b1fc86687bf67149e0bafaa4d6da432232fa956472d1b37f19121d3ace"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bevy_animation",
  "bevy_app",
  "bevy_asset",
@@ -1336,6 +1344,9 @@ name = "bitflags"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "blake3"
@@ -1919,6 +1930,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
+name = "file-id"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6584280525fb2059cba3db2c04abf947a1a29a45ddae89f3870f8281704fafc9"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.4.1",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1989,6 +2021,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2368,6 +2409,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a257582fdcde896fd96463bf2d40eefea0580021c0712a0e2b028b60b47a837a"
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2498,6 +2559,26 @@ dependencies = [
  "libc",
  "libloading 0.7.4",
  "pkg-config",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -2814,6 +2895,39 @@ name = "nonmax"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99756f5493e135528f0cd660ac67b4c3a542bb65a3565efe92bb2c2317eb3669"
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.4.1",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "walkdir",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "notify-debouncer-full"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f5dab59c348b9b50cf7f261960a20e389feb2713636399cd9082cd4b536154"
+dependencies = [
+ "crossbeam-channel",
+ "file-id",
+ "log",
+ "notify",
+ "parking_lot",
+ "walkdir",
+]
 
 [[package]]
 name = "ntapi"
@@ -3291,6 +3405,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3363,13 +3486,14 @@ dependencies = [
 
 [[package]]
 name = "ron"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "300a51053b1cb55c80b7a9fde4120726ddf25ca241a1cbb926626f62fb136bff"
+checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
- "base64",
- "bitflags 1.3.2",
+ "base64 0.21.5",
+ "bitflags 2.4.1",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license     = "PolyForm NonCommercial v1.0"
 default-run = "astratomic"
 
 [dependencies]
-bevy = "0.12"
+bevy = {version = "0.12", features =["file_watcher"]}
 bevy-inspector-egui = "0.22"
 rand = { version = "0.8.5", features = ["small_rng"] }
 fastrand = "2.0.1"
@@ -19,6 +19,7 @@ serde = "1.0"
 serde_derive = "1.0"
 bincode = "1.3.3"
 serde-big-array = "0.5.1"
+ron = "0.8.1"
 bevy-async-task = "1.3.1"
 
 # Enable a small amount of optimization in debug mode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,38 +1,46 @@
 [package]
 name = "astratomic"
 description = "A 2D survival game"
-version = "0.1.1"
-edition = "2021"
+version     = "0.1.1"
+edition     = "2021"
 license     = "PolyForm NonCommercial v1.0"
 default-run = "astratomic"
 
 [dependencies]
-bevy = {version = "0.12", features =["file_watcher"]}
+bevy                = {version = "0.12", features =["file_watcher"]}
 bevy-inspector-egui = "0.22"
-rand = { version = "0.8.5", features = ["small_rng"] }
-fastrand = "2.0.1"
-async-channel = "2.1.0"
-smallvec = "1.11.2"
-itertools = "0.12.0"
+rand                = { version = "0.8.5", features = ["small_rng"] }
+fastrand            = "2.0.1"
+async-channel       = "2.1.0"
+smallvec            = "1.11.2"
+itertools           = "0.12.0"
 
-serde = "1.0"
-serde_derive = "1.0"
-bincode = "1.3.3"
-serde-big-array = "0.5.1"
-ron = "0.8.1"
-bevy-async-task = "1.3.1"
-
-# Enable a small amount of optimization in debug mode
-[profile.dev]
-opt-level = 1
-
-# Enable high optimizations for dependencies (incl. Bevy), but not for our code:
-[profile.dev.package."*"]
-opt-level = 3
+serde               = "1.0"
+serde_derive        = "1.0"
+bincode             = "1.3.3"
+serde-big-array     = "0.5.1"
+ron                 = "0.8.1"
+bevy-async-task     = "1.3.1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 bevy_dylib = "0.12.1"
 
-[profile.release]
+# Optimize dependencies even in development
+[profile.dev.package."*"]
 codegen-units = 1
+debug         = 1 # Only keep line numbers
+opt-level     = 3
+
+# Optimize our code a little bit.
+[profile.dev]
+codegen-units = 256
+opt-level     = 1
+
+[profile.dev-optimized]
+debug     = 1
+inherits  = "dev"
+opt-level = 3
+
+[profile.release]
+codegen-units = 1    # Improved rapier physics perf, so it might help other stuff, too
 lto           = true

--- a/assets/atoms.ron
+++ b/assets/atoms.ron
@@ -13,8 +13,10 @@
     Powder ( inertial_resistance: 0.92),
     //5 Lava
     Liquid ( flow: 1 ),
-    //6 Dirt
+    //6 Grass
     Solid,
-    //7 Rock
-    Solid
+    //7 Dirt
+    Solid,
+    //8 Rock
+    Solid,
 ])

--- a/assets/atoms.ron
+++ b/assets/atoms.ron
@@ -1,0 +1,20 @@
+([
+    //0 Void
+    Void,
+
+    //1 Dummy atom
+    Object,
+
+    //2 Sand
+    Powder,
+    //3 Water
+    Liquid ( flow: 5 ),
+    //4 Gravel
+    Powder,
+    //5 Lava
+    Liquid ( flow: 1 ),
+    //6 Dirt
+    Solid,
+    //7 Rock
+    Solid
+])

--- a/assets/atoms.ron
+++ b/assets/atoms.ron
@@ -6,11 +6,11 @@
     Object,
 
     //2 Sand
-    Powder,
+    Powder ( inertial_resistance: 0.1),
     //3 Water
     Liquid ( flow: 5 ),
     //4 Gravel
-    Powder,
+    Powder ( inertial_resistance: 0.92),
     //5 Lava
     Liquid ( flow: 1 ),
     //6 Dirt

--- a/src/actors.rs
+++ b/src/actors.rs
@@ -13,13 +13,16 @@ pub fn add_actors(
     mut chunk_manager: ResMut<ChunkManager>,
     actors: Query<&Actor>,
     mut dirty_rects: ResMut<DirtyRects>,
+    materials: (Res<Assets<Materials>>, Res<MaterialsHandle>),
 ) {
+    let materials = materials.0.get(materials.1 .0.clone()).unwrap();
+
     for actor in actors.iter() {
         for x_off in 0..actor.width as i32 {
             for y_off in 0..actor.height as i32 {
                 let pos = global_to_chunk(actor.pos + ivec2(x_off, y_off));
                 if let Some(atom) = chunk_manager.get_mut_atom(pos) {
-                    if atom.state == State::Void {
+                    if materials[atom.id].is_void() {
                         *atom = Atom::object();
                     }
                 }
@@ -30,13 +33,19 @@ pub fn add_actors(
 }
 
 //Called after simulation, before actor update
-pub fn remove_actors(mut chunk_manager: ResMut<ChunkManager>, actors: Query<&Actor>) {
+pub fn remove_actors(
+    mut chunk_manager: ResMut<ChunkManager>,
+    actors: Query<&Actor>,
+    materials: (Res<Assets<Materials>>, Res<MaterialsHandle>),
+) {
+    let materials = materials.0.get(materials.1 .0.clone()).unwrap();
+
     for actor in actors.iter() {
         for x_off in 0..actor.width as i32 {
             for y_off in 0..actor.height as i32 {
                 let pos = global_to_chunk(actor.pos + ivec2(x_off, y_off));
                 if let Some(atom) = chunk_manager.get_mut_atom(pos) {
-                    if atom.state == State::Object {
+                    if materials[atom.id].is_object() {
                         *atom = Atom::default();
                     }
                 }
@@ -45,12 +54,12 @@ pub fn remove_actors(mut chunk_manager: ResMut<ChunkManager>, actors: Query<&Act
     }
 }
 
-pub fn on_ground(chunk_manager: &ChunkManager, actor: &Actor) -> bool {
+pub fn on_ground(chunk_manager: &ChunkManager, actor: &Actor, materials: &Materials) -> bool {
     for x_off in 0..actor.width {
         let chunk_pos = global_to_chunk(actor.pos + ivec2(x_off as i32, actor.height as i32));
 
         if let Some(atom) = chunk_manager.get_atom(&chunk_pos) {
-            if atom.state != State::Void {
+            if !materials[atom].is_void() {
                 return true;
             }
         } else {
@@ -61,7 +70,13 @@ pub fn on_ground(chunk_manager: &ChunkManager, actor: &Actor) -> bool {
     false
 }
 
-pub fn update_actors(mut chunk_manager: ResMut<ChunkManager>, mut actors: Query<&mut Actor>) {
+pub fn update_actors(
+    mut chunk_manager: ResMut<ChunkManager>,
+    mut actors: Query<&mut Actor>,
+    materials: (Res<Assets<Materials>>, Res<MaterialsHandle>),
+) {
+    let materials = materials.0.get(materials.1 .0.clone()).unwrap();
+
     for mut actor in actors.iter_mut() {
         let mut prev = actor.pos;
         for v in Line::new(actor.pos, actor.vel.as_ivec2()) {
@@ -73,15 +88,20 @@ pub fn update_actors(mut chunk_manager: ResMut<ChunkManager>, mut actors: Query<
             };
 
             if move_hor {
-                let moved_x = move_x(&mut chunk_manager, &mut actor, (v.x - prev.x).signum());
-                if on_ground(&chunk_manager, &actor) {
+                let moved_x = move_x(
+                    &mut chunk_manager,
+                    &mut actor,
+                    (v.x - prev.x).signum(),
+                    materials,
+                );
+                if on_ground(&chunk_manager, &actor, materials) {
                     let starting_y = actor.pos.y;
                     match moved_x {
                         //If we can't move to the left or right
                         //Check if we can get up a stair-like structure
                         false => {
                             for i in 1..=UP_WALK_HEIGHT {
-                                let moved_y = move_y(&mut chunk_manager, &mut actor, -1);
+                                let moved_y = move_y(&mut chunk_manager, &mut actor, -1, materials);
                                 //Abort if we couldn't move up, or if we moved up but couldn't move sideways on the last step
                                 if !moved_y
                                     || i == UP_WALK_HEIGHT
@@ -89,9 +109,16 @@ pub fn update_actors(mut chunk_manager: ResMut<ChunkManager>, mut actors: Query<
                                             &mut chunk_manager,
                                             &mut actor,
                                             (v.x - prev.x).signum(),
+                                            materials,
                                         )
                                 {
-                                    abort_stair(&mut chunk_manager, &mut actor, starting_y, 1);
+                                    abort_stair(
+                                        &mut chunk_manager,
+                                        &mut actor,
+                                        starting_y,
+                                        1,
+                                        materials,
+                                    );
                                     break;
                                 }
                             }
@@ -100,17 +127,28 @@ pub fn update_actors(mut chunk_manager: ResMut<ChunkManager>, mut actors: Query<
                         //Check if we can snap back to the ground
                         true => {
                             for i in 1..=DOWN_WALK_HEIGHT {
-                                if !move_y(&mut chunk_manager, &mut actor, 1) {
+                                if !move_y(&mut chunk_manager, &mut actor, 1, materials) {
                                     break;
                                 } else if i == DOWN_WALK_HEIGHT {
-                                    abort_stair(&mut chunk_manager, &mut actor, starting_y, -1);
+                                    abort_stair(
+                                        &mut chunk_manager,
+                                        &mut actor,
+                                        starting_y,
+                                        -1,
+                                        materials,
+                                    );
                                 }
                             }
                         }
                     }
                 }
             } else {
-                move_y(&mut chunk_manager, &mut actor, (v.y - prev.y).signum());
+                move_y(
+                    &mut chunk_manager,
+                    &mut actor,
+                    (v.y - prev.y).signum(),
+                    materials,
+                );
             }
 
             prev = v;
@@ -118,13 +156,24 @@ pub fn update_actors(mut chunk_manager: ResMut<ChunkManager>, mut actors: Query<
     }
 }
 
-pub fn abort_stair(chunk_manager: &mut ChunkManager, actor: &mut Actor, starting_y: i32, dir: i32) {
+pub fn abort_stair(
+    chunk_manager: &mut ChunkManager,
+    actor: &mut Actor,
+    starting_y: i32,
+    dir: i32,
+    materials: &Materials,
+) {
     for _ in 0..(starting_y - actor.pos.y) {
-        move_y(chunk_manager, actor, dir);
+        move_y(chunk_manager, actor, dir, materials);
     }
 }
 
-pub fn move_x(chunk_manager: &mut ChunkManager, actor: &mut Actor, dir: i32) -> bool {
+pub fn move_x(
+    chunk_manager: &mut ChunkManager,
+    actor: &mut Actor,
+    dir: i32,
+    materials: &Materials,
+) -> bool {
     //Check if we can move
     for y_off in 0..actor.height as i32 {
         let pos = actor.pos
@@ -139,7 +188,7 @@ pub fn move_x(chunk_manager: &mut ChunkManager, actor: &mut Actor, dir: i32) -> 
 
         // Check bounds and if it's free to move
         if let Some(atom) = chunk_manager.get_mut_atom(chunk_pos) {
-            if atom.state == State::Powder || atom.state == State::Solid {
+            if materials[atom.id].is_powder() || materials[atom.id].is_solid() {
                 actor.vel = Vec2::ZERO;
                 return false;
             }
@@ -154,7 +203,12 @@ pub fn move_x(chunk_manager: &mut ChunkManager, actor: &mut Actor, dir: i32) -> 
     true
 }
 
-pub fn move_y(chunk_manager: &mut ChunkManager, actor: &mut Actor, dir: i32) -> bool {
+pub fn move_y(
+    chunk_manager: &mut ChunkManager,
+    actor: &mut Actor,
+    dir: i32,
+    materials: &Materials,
+) -> bool {
     //Check if we can move
     for x_off in 0..actor.width as i32 {
         let pos = actor.pos
@@ -169,7 +223,7 @@ pub fn move_y(chunk_manager: &mut ChunkManager, actor: &mut Actor, dir: i32) -> 
 
         // Check bounds and if it's free to move
         if let Some(atom) = chunk_manager.get_mut_atom(chunk_pos) {
-            if atom.state == State::Powder || atom.state == State::Solid {
+            if materials[atom.id].is_powder() || materials[atom.id].is_solid() {
                 actor.vel = Vec2::ZERO;
                 return false;
             }

--- a/src/actors.rs
+++ b/src/actors.rs
@@ -59,7 +59,7 @@ pub fn on_ground(chunk_manager: &ChunkManager, actor: &Actor, materials: &Materi
         let chunk_pos = global_to_chunk(actor.pos + ivec2(x_off as i32, actor.height as i32));
 
         if let Some(atom) = chunk_manager.get_atom(&chunk_pos) {
-            if !materials[atom].is_void() {
+            if materials[atom].is_powder() || materials[atom].is_solid() {
                 return true;
             }
         } else {
@@ -127,7 +127,9 @@ pub fn update_actors(
                         //Check if we can snap back to the ground
                         true => {
                             for i in 1..=DOWN_WALK_HEIGHT {
-                                if !move_y(&mut chunk_manager, &mut actor, 1, materials) {
+                                if !move_y(&mut chunk_manager, &mut actor, 1, materials)
+                                    && on_ground(&chunk_manager, &actor, materials)
+                                {
                                     break;
                                 } else if i == DOWN_WALK_HEIGHT {
                                     abort_stair(

--- a/src/atom.rs
+++ b/src/atom.rs
@@ -9,6 +9,7 @@ use crate::prelude::*;
 pub struct Atom {
     pub color: [u8; 4],
     pub state: State,
+    pub properties: Option<Properties>,
 
     #[serde(skip)]
     pub speed: (i8, i8),
@@ -27,6 +28,70 @@ impl Atom {
             ..Default::default()
         }
     }
+
+    //TODO Change this to a yaml file
+    pub fn new(id: u8) -> Atom {
+        let mut atom = Atom::default();
+
+        //Change color and state, etc
+        match id {
+            0 => {
+                //Sand
+                atom.state = State::Powder;
+                atom.color = [
+                    (230 + rand::thread_rng().gen_range(-20_i16..20_i16)) as u8,
+                    (197 + rand::thread_rng().gen_range(-20_i16..20_i16)) as u8,
+                    (92 + rand::thread_rng().gen_range(-20_i16..20_i16)) as u8,
+                    255,
+                ];
+            }
+            1 => {
+                //Water
+                atom.state = State::Liquid;
+                atom.color = [
+                    (20 + rand::thread_rng().gen_range(-20_i16..20_i16)) as u8,
+                    (125 + rand::thread_rng().gen_range(-20_i16..20_i16)) as u8,
+                    (204 + rand::thread_rng().gen_range(-20_i16..20_i16)) as u8,
+                    150,
+                ];
+                atom.properties = Some(Properties::Liquid { flow: 5 });
+            }
+            2 => {
+                //Gravel
+                atom.state = State::Powder;
+                atom.color = [
+                    (110 + rand::thread_rng().gen_range(-12_i16..12_i16)) as u8,
+                    (110 + rand::thread_rng().gen_range(-12_i16..12_i16)) as u8,
+                    (110 + rand::thread_rng().gen_range(-12_i16..12_i16)) as u8,
+                    255,
+                ];
+            }
+            3 => {
+                //Lava
+                atom.state = State::Liquid;
+                atom.color = [
+                    (245 + rand::thread_rng().gen_range(-10_i16..10_i16)) as u8,
+                    (140 + rand::thread_rng().gen_range(-20_i16..20_i16)) as u8,
+                    (10 + rand::thread_rng().gen_range(-10_i16..10_i16)) as u8,
+                    255,
+                ];
+                atom.properties = Some(Properties::Liquid { flow: 1 });
+            }
+            4 => {
+                //Dirt
+                atom.state = State::Powder;
+                atom.color = [
+                    (120 + rand::thread_rng().gen_range(-10_i16..10_i16)) as u8,
+                    (70 + rand::thread_rng().gen_range(-10_i16..10_i16)) as u8,
+                    (40 + rand::thread_rng().gen_range(-5_i16..5_i16)) as u8,
+                    255,
+                ];
+            }
+            _ => panic!("Atom not found, invalid ID."),
+        }
+
+        atom
+    }
 }
 
 // TODO Change this to a Material type
@@ -39,6 +104,11 @@ pub enum State {
     Object,
     #[default]
     Void,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq)]
+pub enum Properties {
+    Liquid { flow: u8 },
 }
 
 // Update different types of atoms
@@ -90,7 +160,12 @@ pub fn update_powder(chunks: &mut UpdateChunksType, pos: IVec2, dt: u8) -> HashS
 }
 
 /// Updates liquid and returns atoms awakened
-pub fn update_liquid(chunks: &mut UpdateChunksType, pos: IVec2, dt: u8) -> HashSet<IVec2> {
+pub fn update_liquid(
+    chunks: &mut UpdateChunksType,
+    pos: IVec2,
+    flow: u8,
+    dt: u8,
+) -> HashSet<IVec2> {
     let mut awakened = HashSet::new();
     let mut cur_pos = pos;
 
@@ -129,7 +204,7 @@ pub fn update_liquid(chunks: &mut UpdateChunksType, pos: IVec2, dt: u8) -> HashS
         };
 
         if let Some(side) = side {
-            for _ in 0..5 {
+            for _ in 0..flow {
                 let state = get_state(chunks, cur_pos);
                 if !swapable(chunks, cur_pos + IVec2::new(side, 0), &[], state, dt) {
                     break;

--- a/src/atom.rs
+++ b/src/atom.rs
@@ -76,11 +76,29 @@ impl Atom {
                 ];
             }
             6 => {
+                //Grass
+                atom.color = [
+                    (30 + rand::thread_rng().gen_range(-10_i16..10_i16)) as u8,
+                    (170 + rand::thread_rng().gen_range(-10_i16..10_i16)) as u8,
+                    (10 + rand::thread_rng().gen_range(-5_i16..5_i16)) as u8,
+                    255,
+                ];
+            }
+            7 => {
                 //Dirt
                 atom.color = [
                     (120 + rand::thread_rng().gen_range(-10_i16..10_i16)) as u8,
                     (70 + rand::thread_rng().gen_range(-10_i16..10_i16)) as u8,
                     (40 + rand::thread_rng().gen_range(-5_i16..5_i16)) as u8,
+                    255,
+                ];
+            }
+            8 => {
+                //Rock
+                atom.color = [
+                    (80 + rand::thread_rng().gen_range(-10_i16..10_i16)) as u8,
+                    (80 + rand::thread_rng().gen_range(-10_i16..10_i16)) as u8,
+                    (80 + rand::thread_rng().gen_range(-5_i16..5_i16)) as u8,
                     255,
                 ];
             }

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -31,7 +31,7 @@ impl Chunk {
             Ordering::Less => {}
             _ => {
                 for atom in &mut atoms {
-                    atom.state = State::Powder;
+                    atom.id = 2;
                     atom.color = [
                         (230 + rand::thread_rng().gen_range(-20_i16..20_i16)) as u8,
                         (197 + rand::thread_rng().gen_range(-20_i16..20_i16)) as u8,

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -1,5 +1,4 @@
 use bevy::render::render_resource::*;
-use rand::Rng;
 use std::cmp::Ordering;
 use std::collections::HashSet;
 
@@ -31,13 +30,7 @@ impl Chunk {
             Ordering::Less => {}
             _ => {
                 for atom in &mut atoms {
-                    atom.id = 2;
-                    atom.color = [
-                        (230 + rand::thread_rng().gen_range(-20_i16..20_i16)) as u8,
-                        (197 + rand::thread_rng().gen_range(-20_i16..20_i16)) as u8,
-                        (92 + rand::thread_rng().gen_range(-20_i16..20_i16)) as u8,
-                        255,
-                    ];
+                    *atom = Atom::new(4);
                 }
             }
         }

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -28,9 +28,21 @@ impl Chunk {
 
         match index.y.cmp(&2) {
             Ordering::Less => {}
-            _ => {
+            Ordering::Equal => {
+                for (i, atom) in atoms.iter_mut().enumerate() {
+                    let id = match i {
+                        0..=511 => 6,
+                        512..=2815 => 7,
+                        _ => 4,
+                    };
+
+                    *atom = Atom::new(id);
+                }
+            }
+
+            Ordering::Greater => {
                 for atom in &mut atoms {
-                    *atom = Atom::new(4);
+                    *atom = Atom::new(8);
                 }
             }
         }

--- a/src/chunk_manager.rs
+++ b/src/chunk_manager.rs
@@ -212,6 +212,7 @@ pub fn manager_setup(
 pub fn chunk_manager_update(
     mut chunk_manager: ResMut<ChunkManager>,
     mut dirty_rects_resource: ResMut<DirtyRects>,
+    materials: (Res<Assets<Materials>>, Res<MaterialsHandle>),
 ) {
     chunk_manager.dt = chunk_manager.dt.wrapping_add(1);
     let dt = chunk_manager.dt;
@@ -222,6 +223,9 @@ pub fn chunk_manager_update(
         new: new_dirty_rects,
         render: render_dirty_rects,
     } = &mut *dirty_rects_resource;
+
+    //Get materials
+    let materials = &materials.0.get(materials.1 .0.clone()).unwrap();
 
     let first_x = chunk_manager.pos.x;
     let first_y = chunk_manager.pos.y;
@@ -370,6 +374,7 @@ pub fn chunk_manager_update(
                                 group: chunk_group,
                                 dirty_update_rect_send,
                                 dirty_render_rect_send,
+                                materials,
                             },
                             dt,
                             rect,
@@ -389,6 +394,8 @@ pub fn chunk_manager_update(
 }
 
 pub fn update_chunks(chunks: &mut UpdateChunksType, dt: u8, dirty_rect: &URect) {
+    let materials = chunks.materials;
+
     let x_iter = rand_range(dirty_rect.min.x as i32..dirty_rect.max.x as i32 + 1).into_iter();
     let y_iter = rand_range(dirty_rect.min.y as i32..dirty_rect.max.y as i32 + 1).into_iter();
     for (y, x) in y_iter.cartesian_product(x_iter) {
@@ -400,16 +407,17 @@ pub fn update_chunks(chunks: &mut UpdateChunksType, dt: u8, dirty_rect: &URect) 
         }
 
         let mut awake_self = false;
-        let state;
+        let id;
         let speed;
-        let prop;
         {
             let atom = &mut chunks.group[local_pos];
-            state = atom.state;
+            id = atom.id;
             speed = atom.speed;
-            prop = atom.properties;
 
-            if atom.f_idle < FRAMES_SLEEP && state != State::Void && state != State::Solid {
+            if atom.f_idle < FRAMES_SLEEP
+                && materials[id] != Material::Void
+                && materials[id] != Material::Solid
+            {
                 atom.f_idle += 1;
                 awake_self = true;
             }
@@ -418,16 +426,9 @@ pub fn update_chunks(chunks: &mut UpdateChunksType, dt: u8, dirty_rect: &URect) 
         let (vector, mut awakened) = if speed.0 == 0 && speed.1 >= 0 {
             (
                 false,
-                match state {
-                    State::Powder => update_powder(chunks, pos, dt),
-                    State::Liquid => {
-                        let flow = if let Some(Properties::Liquid { flow }) = prop {
-                            flow
-                        } else {
-                            3
-                        };
-                        update_liquid(chunks, pos, flow, dt)
-                    }
+                match materials[id] {
+                    Material::Powder => update_powder(chunks, pos, dt),
+                    Material::Liquid { flow } => update_liquid(chunks, pos, flow, dt),
                     _ => HashSet::new(),
                 },
             )

--- a/src/chunk_manager.rs
+++ b/src/chunk_manager.rs
@@ -427,7 +427,9 @@ pub fn update_chunks(chunks: &mut UpdateChunksType, dt: u8, dirty_rect: &URect) 
             (
                 false,
                 match materials[id] {
-                    Material::Powder => update_powder(chunks, pos, dt),
+                    Material::Powder {
+                        inertial_resistance,
+                    } => update_powder(chunks, pos, dt, inertial_resistance),
                     Material::Liquid { flow } => update_liquid(chunks, pos, flow, dt),
                     _ => HashSet::new(),
                 },
@@ -436,17 +438,19 @@ pub fn update_chunks(chunks: &mut UpdateChunksType, dt: u8, dirty_rect: &URect) 
             (true, update_atom(chunks, pos, dt))
         };
 
+        let atom = &mut chunks.group[local_pos];
         let mut self_awakened = HashSet::new();
         if awakened.contains(&pos) {
-            let atom = &mut chunks.group[local_pos];
             atom.f_idle = 0;
+            atom.moving = true;
         } else if vector {
-            let atom = &mut chunks.group[local_pos];
             atom.f_idle = 0;
             awakened.insert(pos);
+            atom.moving = false;
         } else if awake_self {
             awakened.insert(pos);
             self_awakened.insert(pos);
+            atom.moving = false;
         }
 
         for awoke in awakened {

--- a/src/chunk_manager.rs
+++ b/src/chunk_manager.rs
@@ -402,10 +402,12 @@ pub fn update_chunks(chunks: &mut UpdateChunksType, dt: u8, dirty_rect: &URect) 
         let mut awake_self = false;
         let state;
         let speed;
+        let prop;
         {
             let atom = &mut chunks.group[local_pos];
             state = atom.state;
             speed = atom.speed;
+            prop = atom.properties;
 
             if atom.f_idle < FRAMES_SLEEP && state != State::Void && state != State::Solid {
                 atom.f_idle += 1;
@@ -418,7 +420,14 @@ pub fn update_chunks(chunks: &mut UpdateChunksType, dt: u8, dirty_rect: &URect) 
                 false,
                 match state {
                     State::Powder => update_powder(chunks, pos, dt),
-                    State::Liquid => update_liquid(chunks, pos, dt),
+                    State::Liquid => {
+                        let flow = if let Some(Properties::Liquid { flow }) = prop {
+                            flow
+                        } else {
+                            3
+                        };
+                        update_liquid(chunks, pos, flow, dt)
+                    }
                     _ => HashSet::new(),
                 },
             )

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -10,7 +10,7 @@ pub const QUARTER_CHUNK_LEN: usize = CHUNK_LEN / 4;
 // Actor consts
 
 pub const UP_WALK_HEIGHT: usize = 3;
-pub const DOWN_WALK_HEIGHT: usize = 6;
+pub const DOWN_WALK_HEIGHT: usize = 4;
 
 // Player consts
 pub const FUEL_MAX: f32 = 50.;
@@ -19,7 +19,9 @@ pub const FUEL_COMSUMPTON: f32 = 0.48;
 pub const JETPACK_FORCE: f32 = 1.5;
 pub const JETPACK_MAX: f32 = 3.;
 
-pub const JUMP_MAG: f32 = 13.;
+pub const JUMP_MAG: f32 = 9.;
+pub const PRESSED_JUMP_MAG: f32 = 0.6;
+pub const TIME_JUMP_PRESSED: f64 = 0.8;
 pub const RUN_SPEED: f32 = 3.5;
 
 pub const TOOL_DISTANCE: f32 = 32.;

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -33,7 +33,7 @@ pub const TOOL_RANGE: f32 = 12.;
 
 pub const GRAVITY: u8 = 1;
 pub const TERM_VEL: u8 = 10;
-pub const FRAMES_SLEEP: u8 = 4;
+pub const FRAMES_SLEEP: u8 = 1;
 //Has to be even
 pub const LOAD_WIDTH: i32 = 20;
 pub const LOAD_HEIGHT: i32 = 12;

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -20,7 +20,7 @@ fn brush(
     } else if input.1.pressed(KeyCode::ControlLeft) {
         atom = Atom::new(3);
     } else if input.1.pressed(KeyCode::ShiftLeft) {
-        atom = Atom::new(4);
+        atom = Atom::new(8);
     } else {
         return;
     }

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -16,11 +16,11 @@ fn brush(
 ) {
     let atom;
     if input.0.pressed(MouseButton::Middle) {
-        atom = Atom::new(0);
-    } else if input.1.pressed(KeyCode::ControlLeft) {
-        atom = Atom::new(1);
-    } else if input.1.pressed(KeyCode::ShiftLeft) {
         atom = Atom::new(2);
+    } else if input.1.pressed(KeyCode::ControlLeft) {
+        atom = Atom::new(3);
+    } else if input.1.pressed(KeyCode::ShiftLeft) {
+        atom = Atom::new(4);
     } else {
         return;
     }

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
 use bevy::sprite::Anchor;
-use rand::Rng;
 
 use bevy::diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin};
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
@@ -15,30 +14,13 @@ fn brush(
     prev_mpos: Res<PreviousMousePos>,
     input: (Res<Input<MouseButton>>, Res<Input<KeyCode>>),
 ) {
-    let (state, color);
-
-    if input.1.pressed(KeyCode::L) {
-        state = State::Gas;
-        color = [255, 255, 255, 255];
-    } else if input.0.pressed(MouseButton::Middle) {
-        state = State::Powder;
-        color = [
-            (230 + rand::thread_rng().gen_range(-20_i16..20_i16)) as u8,
-            (197 + rand::thread_rng().gen_range(-20_i16..20_i16)) as u8,
-            (92 + rand::thread_rng().gen_range(-20_i16..20_i16)) as u8,
-            255,
-        ];
+    let atom;
+    if input.0.pressed(MouseButton::Middle) {
+        atom = Atom::new(0);
     } else if input.1.pressed(KeyCode::ControlLeft) {
-        state = State::Liquid;
-        color = [
-            (20 + rand::thread_rng().gen_range(-20_i16..20_i16)) as u8,
-            (125 + rand::thread_rng().gen_range(-20_i16..20_i16)) as u8,
-            (204 + rand::thread_rng().gen_range(-20_i16..20_i16)) as u8,
-            150,
-        ];
+        atom = Atom::new(1);
     } else if input.1.pressed(KeyCode::ShiftLeft) {
-        state = State::Solid;
-        color = [127, 131, 134, 255];
+        atom = Atom::new(2);
     } else {
         return;
     }
@@ -63,12 +45,6 @@ fn brush(
             if chunk_manager.get_atom(&pos).is_none() {
                 continue;
             }
-
-            let atom = Atom {
-                color,
-                state,
-                ..Default::default()
-            };
 
             chunk_manager[pos] = atom;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,13 +10,13 @@ mod consts;
 mod debug;
 mod geom_tools;
 mod manager_api;
+mod materials;
 mod particles;
 mod player;
 mod prelude {
-    pub use crate::atom::State;
     pub use crate::{
         actors::*, animation::*, atom::*, chunk::*, chunk_group::*, chunk_manager::*, consts::*,
-        debug::*, geom_tools::*, manager_api::*, particles::*, player::*,
+        debug::*, geom_tools::*, manager_api::*, materials::*, particles::*, player::*,
     };
     pub use bevy::input::mouse::MouseScrollUnit;
     pub use bevy::input::mouse::MouseWheel;
@@ -33,6 +33,8 @@ mod prelude {
     pub use std::fs;
     pub use std::fs::File;
     pub use std::io::Write;
+
+    pub use crate::materials::Material;
 }
 
 use prelude::*;
@@ -50,6 +52,7 @@ fn main() {
             PlayerPlugin,
             animation::AnimationPlugin,
             ParticlesPlugin,
+            MaterialsPlugin,
         ))
         .add_systems(Startup, setup_camera);
 

--- a/src/manager_api.rs
+++ b/src/manager_api.rs
@@ -126,7 +126,12 @@ pub fn down_neigh(
     let mut neigh = [(false, IVec2::ZERO); 3];
 
     let material = get_material(chunks, pos);
-    for (neigh, x) in neigh.iter_mut().zip([0, -1, 1]) {
+    let to_check = if material.is_powder() && !get_moving(chunks, pos) {
+        vec![0]
+    } else {
+        vec![0, -1, 1]
+    };
+    for (neigh, x) in neigh.iter_mut().zip(to_check) {
         neigh.0 = swapable(chunks, pos + IVec2::new(x, 1), ids, material, dt);
         neigh.1 = IVec2::new(x, 1);
     }
@@ -187,6 +192,22 @@ pub fn set_vel(chunks: &mut UpdateChunksType, pos: IVec2, vel: IVec2) {
 /// Gets material from a global pos
 pub fn get_material(chunks: &UpdateChunksType, pos: IVec2) -> Material {
     chunks.materials.0[chunks.group[pos].id as usize]
+}
+
+/// Gets if atom is moving
+pub fn set_moving(chunks: &mut UpdateChunksType, pos: IVec2, inertial_resistance: f32) {
+    for x_off in [-1, 1] {
+        if fastrand::f32() > inertial_resistance {
+            chunks.group[pos + ivec2(x_off, 0)].moving = true;
+        } else {
+            break;
+        }
+    }
+}
+
+/// Gets if atom is moving
+pub fn get_moving(chunks: &UpdateChunksType, pos: IVec2) -> bool {
+    chunks.group[pos].moving
 }
 
 /// Checks if atom is able to update this frame from a global pos

--- a/src/manager_api.rs
+++ b/src/manager_api.rs
@@ -11,20 +11,21 @@ pub struct UpdateChunksType<'a> {
     pub group: ChunkGroup<'a>,
     pub dirty_update_rect_send: &'a Sender<DeferredDirtyRectUpdate>,
     pub dirty_render_rect_send: &'a Sender<DeferredDirtyRectUpdate>,
+    pub materials: &'a Materials,
 }
 
 /// Swap two atoms from global 3x3 chunks positions
 pub fn swap(chunks: &mut UpdateChunksType, pos1: IVec2, pos2: IVec2, dt: u8) {
-    let states = [get_state(chunks, pos1), get_state(chunks, pos2)];
+    let materials = [get_material(chunks, pos1), get_material(chunks, pos2)];
     let chunk_group = &mut chunks.group;
     {
         let temp = chunk_group[pos1];
-        chunk_group[pos1] = if states[1] == State::Object {
+        chunk_group[pos1] = if materials[1].is_object() {
             Atom::default()
         } else {
             chunk_group[pos2]
         };
-        chunk_group[pos2] = if states[0] == State::Object {
+        chunk_group[pos2] = if materials[0].is_object() {
             Atom::default()
         } else {
             temp
@@ -93,20 +94,23 @@ pub fn global_to_chunk(mut pos: IVec2) -> ChunkPos {
 }
 
 /// See if position is swapable, that means it sees if the position is a void
-/// or if it's a swapable state and has been not updated
+/// or if it's a swapable material and has been not updated
 pub fn swapable(
     chunks: &UpdateChunksType,
     pos: IVec2,
-    states: &[(State, f32)],
-    state: State,
+    ids: &[(u8, f32)],
+    material: Material,
     dt: u8,
 ) -> bool {
     if let Some(atom) = chunks.group.get_global(pos) {
-        atom.state == State::Void
-            || (states.iter().any(|&(state, prob)| {
-                state == atom.state && rand::thread_rng().gen_range(0.0..1.0) < prob
-            }) && atom.updated_at != dt)
-            || (atom.state == State::Object && state == State::Liquid)
+        let atom_material = chunks.materials.0[atom.id as usize];
+
+        atom_material == Material::Void
+            || (ids
+                .iter()
+                .any(|&(id, prob)| id == atom.id && rand::thread_rng().gen_range(0.0..1.0) < prob)
+                && atom.updated_at != dt)
+            || (atom_material.is_object() && material.is_liquid())
     } else {
         false
     }
@@ -116,14 +120,14 @@ pub fn swapable(
 pub fn down_neigh(
     chunks: &UpdateChunksType,
     pos: IVec2,
-    states: &[(State, f32)],
+    ids: &[(u8, f32)],
     dt: u8,
 ) -> [(bool, IVec2); 3] {
     let mut neigh = [(false, IVec2::ZERO); 3];
 
-    let state = get_state(chunks, pos);
+    let material = get_material(chunks, pos);
     for (neigh, x) in neigh.iter_mut().zip([0, -1, 1]) {
-        neigh.0 = swapable(chunks, pos + IVec2::new(x, 1), states, state, dt);
+        neigh.0 = swapable(chunks, pos + IVec2::new(x, 1), ids, material, dt);
         neigh.1 = IVec2::new(x, 1);
     }
 
@@ -138,14 +142,14 @@ pub fn down_neigh(
 pub fn side_neigh(
     chunks: &UpdateChunksType,
     pos: IVec2,
-    states: &[(State, f32)],
+    ids: &[(u8, f32)],
     dt: u8,
 ) -> [(bool, IVec2); 2] {
     let mut neigh = [(false, IVec2::ZERO); 2];
 
-    let state = get_state(chunks, pos);
+    let material = get_material(chunks, pos);
     for (neigh, x) in neigh.iter_mut().zip([-1, 1]) {
-        neigh.0 = swapable(chunks, pos + IVec2::new(x, 0), states, state, dt);
+        neigh.0 = swapable(chunks, pos + IVec2::new(x, 0), ids, material, dt);
         neigh.1 = IVec2::new(x, 0);
     }
 
@@ -180,15 +184,15 @@ pub fn set_vel(chunks: &mut UpdateChunksType, pos: IVec2, vel: IVec2) {
     chunks.group[pos].speed.1 = vel.y as i8;
 }
 
-/// Gets state from a global pos
-pub fn get_state(chunks: &UpdateChunksType, pos: IVec2) -> State {
-    chunks.group[pos].state
+/// Gets material from a global pos
+pub fn get_material(chunks: &UpdateChunksType, pos: IVec2) -> Material {
+    chunks.materials.0[chunks.group[pos].id as usize]
 }
 
 /// Checks if atom is able to update this frame from a global pos
 pub fn dt_updatable(chunks: &UpdateChunksType, pos: IVec2, dt: u8) -> bool {
     if let Some(atom) = chunks.group.get_global(pos) {
-        atom.updated_at != dt || atom.state == State::Void
+        atom.updated_at != dt || (chunks.materials.0[atom.id as usize]).is_void()
     } else {
         false
     }

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -120,7 +120,6 @@ impl AssetLoader for MaterialsLoader {
 
 pub fn setup(mut materials_handle: ResMut<MaterialsHandle>, asset_server: Res<AssetServer>) {
     materials_handle.0 = asset_server.load("atoms.ron");
-    println!("{:#?}", materials_handle.0);
 }
 
 pub struct MaterialsPlugin;

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -13,7 +13,9 @@ use thiserror::Error;
 #[derive(Default, Debug, Deserialize, PartialEq, Clone, Copy)]
 pub enum Material {
     Solid,
-    Powder,
+    Powder {
+        inertial_resistance: f32,
+    },
     Liquid {
         flow: u8,
     },
@@ -37,7 +39,7 @@ impl Material {
     }
 
     pub fn is_powder(&self) -> bool {
-        matches!(self, Material::Powder)
+        matches!(self, Material::Powder { .. })
     }
 
     pub fn is_solid(&self) -> bool {

--- a/src/materials.rs
+++ b/src/materials.rs
@@ -1,0 +1,132 @@
+use crate::prelude::*;
+
+use bevy::utils::thiserror;
+use bevy::{
+    asset::{io::Reader, AssetLoader, AsyncReadExt, LoadContext},
+    prelude::*,
+    reflect::TypePath,
+    utils::BoxedFuture,
+};
+use serde::Deserialize;
+use thiserror::Error;
+
+#[derive(Default, Debug, Deserialize, PartialEq, Clone, Copy)]
+pub enum Material {
+    Solid,
+    Powder,
+    Liquid {
+        flow: u8,
+    },
+    Gas,
+    Object,
+    #[default]
+    Void,
+}
+
+impl Material {
+    pub fn is_liquid(&self) -> bool {
+        matches!(self, Material::Liquid { .. })
+    }
+
+    pub fn is_void(&self) -> bool {
+        matches!(self, Material::Void)
+    }
+
+    pub fn is_object(&self) -> bool {
+        matches!(self, Material::Object)
+    }
+
+    pub fn is_powder(&self) -> bool {
+        matches!(self, Material::Powder)
+    }
+
+    pub fn is_solid(&self) -> bool {
+        matches!(self, Material::Solid)
+    }
+}
+
+#[derive(Asset, TypePath, Debug, Deserialize)]
+pub struct Materials(pub Vec<Material>);
+
+impl Materials {
+    pub fn get_from_atom(&self, atom: &Atom) -> &Material {
+        &self.0[atom.id as usize]
+    }
+
+    pub fn get_from_id(&self, id: u8) -> &Material {
+        &self.0[id as usize]
+    }
+}
+
+impl std::ops::Index<&Atom> for Materials {
+    type Output = Material;
+    #[track_caller]
+    fn index(&self, atom: &Atom) -> &Self::Output {
+        self.get_from_atom(atom)
+    }
+}
+
+impl std::ops::Index<u8> for Materials {
+    type Output = Material;
+    #[track_caller]
+    fn index(&self, id: u8) -> &Self::Output {
+        self.get_from_id(id)
+    }
+}
+
+//Asset stuff
+
+#[derive(Resource, Default)]
+pub struct MaterialsHandle(pub Handle<Materials>);
+
+#[derive(Default)]
+pub struct MaterialsLoader;
+
+#[non_exhaustive]
+#[derive(Debug, Error)]
+pub enum MaterialsLoaderError {
+    /// An [IO](std::io) Error
+    #[error("Could not load asset: {0}")]
+    Io(#[from] std::io::Error),
+    /// A [RON](ron) Error
+    #[error("Could not parse RON: {0}")]
+    RonSpannedError(#[from] ron::error::SpannedError),
+}
+
+impl AssetLoader for MaterialsLoader {
+    type Asset = Materials;
+    type Settings = ();
+    type Error = MaterialsLoaderError;
+    fn load<'a>(
+        &'a self,
+        reader: &'a mut Reader,
+        _settings: &'a (),
+        _load_context: &'a mut LoadContext,
+    ) -> BoxedFuture<'a, Result<Self::Asset, Self::Error>> {
+        Box::pin(async move {
+            let mut bytes = Vec::new();
+            reader.read_to_end(&mut bytes).await?;
+            let custom_asset = ron::de::from_bytes::<Materials>(&bytes)?;
+            Ok(custom_asset)
+        })
+    }
+
+    fn extensions(&self) -> &[&str] {
+        &["ron"]
+    }
+}
+
+pub fn setup(mut materials_handle: ResMut<MaterialsHandle>, asset_server: Res<AssetServer>) {
+    materials_handle.0 = asset_server.load("atoms.ron");
+    println!("{:#?}", materials_handle.0);
+}
+
+pub struct MaterialsPlugin;
+impl Plugin for MaterialsPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_asset::<Materials>()
+            .init_resource::<MaterialsHandle>()
+            .init_asset_loader::<MaterialsLoader>()
+            .add_systems(Startup, setup);
+    }
+}

--- a/src/player.rs
+++ b/src/player.rs
@@ -165,8 +165,6 @@ pub fn update_player(
         player.atom_id = 4;
     } else if keys.just_pressed(KeyCode::Key4) {
         player.atom_id = 5;
-    } else if keys.just_pressed(KeyCode::Key5) {
-        player.atom_id = 6;
     }
 }
 
@@ -219,7 +217,7 @@ pub fn tool_system(
         let mut pos_to_update = vec![];
         if mouse.pressed(MouseButton::Right) {
             let new_tool_front = tool_front + tool_slope * 2.;
-            let n = 12;
+            let n = 6;
 
             for i in 0..=n {
                 let angle = fastrand::f32() * std::f32::consts::TAU;


### PR DESCRIPTION
This adds a lot of stuff!

New material type, that you can modify on the `atoms.ron` file, that supports hot reloading.
For now you can change the inertial resistance of powders, and change the flow rate of liquids.
The flow changes how fast a liquid spreads, and the inertial resistance changes how likely it is to a powder to spread to the sides

New atoms!
Lava, Water, Dirt, Grass, Gravel and Rock!

You can press:
`1` to shoot sand
`2` to shoot water
`3` to shoot gravel
`4` to shoot lava

For Rock and Dirt we need a new precision mode for the tool, as they are solids and do not move and need to be placed in a square or circle shape, and not thrown.

And also, some improvements to the player:

New "states" for the animation, will later be added to a ron or yaml file.
Easier to navigate when using the jetpack.
Now you can hold space to jump higher.

Closes #33 